### PR TITLE
Fix issues with message delivery after initial welcome message

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -49,7 +49,7 @@ GEM
     database_cleaner (1.6.1)
     databox (2.0.0)
       httparty
-    declarative (0.0.9)
+    declarative (0.0.10)
     declarative-option (0.1.0)
     descendants_tracker (0.0.4)
       thread_safe (~> 0.3, >= 0.3.1)
@@ -59,29 +59,30 @@ GEM
     escape_utils (1.0.1)
     faraday (0.15.2)
       multipart-post (>= 1.2, < 3)
-    faraday_middleware (0.11.0.1)
+    faraday_middleware (0.12.2)
       faraday (>= 0.7.4, < 1.0)
-    foreman (0.84.0)
+    foreman (0.85.0)
       thor (~> 0.19.1)
     gemoji (2.1.0)
     gist (4.6.1)
-    gli (2.16.0)
-    grape (1.0.0)
+    gli (2.17.1)
+    grape (1.0.3)
       activesupport
       builder
       mustermann-grape (~> 1.0.0)
       rack (>= 1.3.0)
       rack-accept
       virtus (>= 1.0.0)
-    grape-roar (0.4.0)
+    grape-roar (0.4.1)
       grape
+      multi_json
       roar (~> 1.1.0)
-    grape-swagger (0.27.2)
+    grape-swagger (0.29.0)
       grape (>= 0.16.2)
-    hashie (3.5.5)
+    hashie (3.5.7)
     hashie-forbidden_attributes (0.1.1)
       hashie (>= 3.0)
-    hitimes (1.2.5)
+    hitimes (1.3.0)
     html-pipeline (2.6.0)
       activesupport (>= 2)
       nokogiri (>= 1.4)
@@ -96,30 +97,30 @@ GEM
     http_parser.rb (0.6.0)
     httparty (0.15.6)
       multi_xml (>= 0.5.2)
-    i18n (0.8.4)
+    i18n (0.9.5)
+      concurrent-ruby (~> 1.0)
     ice_nine (0.11.2)
-    json (2.1.0)
-    kaminari-core (1.0.1)
+    kaminari-core (1.1.1)
     kaminari-grape (1.0.1)
       grape
       kaminari-core (~> 1.0)
-    kgio (2.11.0)
+    kgio (2.11.2)
     metaclass (0.0.4)
     mini_portile2 (2.2.0)
-    minitest (5.10.2)
+    minitest (5.11.3)
     minitest-osx (0.1.0)
       minitest (~> 5.4)
       terminal-notifier (~> 1.6)
     mocha (1.2.1)
       metaclass (~> 0.0.1)
-    multi_json (1.12.1)
+    multi_json (1.13.1)
     multi_xml (0.6.0)
     multipart-post (2.0.0)
-    mustermann (1.0.0)
+    mustermann (1.0.2)
     mustermann-grape (1.0.0)
       mustermann (~> 1.0.0)
     newrelic_rpm (4.2.0.334)
-    nio4r (2.1.0)
+    nio4r (2.3.1)
     nokogiri (1.8.0)
       mini_portile2 (~> 2.2.0)
     numerizer (0.1.1)
@@ -128,10 +129,10 @@ GEM
       hashie-forbidden_attributes (~> 0.1)
     pg (0.21.0)
     public_suffix (2.0.5)
-    rack (2.0.3)
+    rack (2.0.5)
     rack-accept (0.4.5)
       rack (>= 0.4)
-    rack-cors (0.4.1)
+    rack-cors (1.0.2)
     rack-protection (2.0.0)
       rack
     rack-rewrite (1.5.1)
@@ -141,7 +142,7 @@ GEM
       rack (>= 1.0)
     rack_csrf (2.6.0)
       rack (>= 1.1.0)
-    raindrops (0.18.0)
+    raindrops (0.19.0)
     rake (12.0.0)
     representable (3.0.4)
       declarative (< 0.1.0)
@@ -157,7 +158,7 @@ GEM
       rack (~> 2.0)
       rack-protection (= 2.0.0)
       tilt (~> 2.0)
-    slack-ruby-bot (0.10.4)
+    slack-ruby-bot (0.11.1)
       hashie
       slack-ruby-client (>= 0.6.0)
     slack-ruby-bot-server (0.6.1)
@@ -172,13 +173,12 @@ GEM
       rack-server-pages
       slack-ruby-bot
       unicorn
-    slack-ruby-client (0.8.1)
+    slack-ruby-client (0.11.1)
       activesupport
       faraday (>= 0.9)
       faraday_middleware
       gli
       hashie
-      json
       websocket-driver
     slack_markdown (0.2.0)
       escape_utils (~> 1.0.1)
@@ -190,13 +190,13 @@ GEM
     tilt (2.0.7)
     timers (4.1.2)
       hitimes
-    tzinfo (1.2.3)
+    tzinfo (1.2.5)
       thread_safe (~> 0.1)
     uber (0.1.0)
     unf (0.1.4)
       unf_ext
     unf_ext (0.0.7.4)
-    unicorn (5.3.0)
+    unicorn (5.4.0)
       kgio (~> 2.6)
       raindrops (~> 0.7)
     virtus (1.0.5)
@@ -204,9 +204,9 @@ GEM
       coercible (~> 1.0)
       descendants_tracker (~> 0.0, >= 0.0.3)
       equalizer (~> 0.0, >= 0.0.9)
-    websocket-driver (0.6.5)
+    websocket-driver (0.7.0)
       websocket-extensions (>= 0.1.0)
-    websocket-extensions (0.1.2)
+    websocket-extensions (0.1.3)
 
 PLATFORMS
   ruby

--- a/lib/aloha/hooks/welcome_new_user.rb
+++ b/lib/aloha/hooks/welcome_new_user.rb
@@ -9,6 +9,7 @@ module Aloha
           user = ::User.find_create_or_update_by_slack_id!(client, data.user.id)
           send_welcome(client, user)
         end
+        Aloha::Server.request_presence_subscriptions(client)
       end
 
       def send_welcome(client, user)

--- a/lib/aloha/server.rb
+++ b/lib/aloha/server.rb
@@ -15,17 +15,17 @@ module Aloha
 
     def start!
       result = super
-      request_presence_subscriptions
+      Aloha::Server.request_presence_subscriptions(client)
       result
     end
 
     def start_async
       result = super
-      request_presence_subscriptions
+      Aloha::Server.request_presence_subscriptions(client)
       result
     end
 
-    def request_presence_subscriptions
+    def self.request_presence_subscriptions(client)
       # pull all members that aren't restricted, or bots
       all_members = []
       client.web_client.users_list(presence: true, limit: 10) do |response|


### PR DESCRIPTION
A Slack API change caused the bot to no longer receive notification from Slack when users came back from away. This was impacting all teams, and preventing Aloha from delivering messages, as the bot only checks the message list when it sees a user become active.

Added explicit subscriptions to presence alerts for all users on startup and when a new user joins a team. 